### PR TITLE
Fix workflow JSON generation - correct data_path configuration

### DIFF
--- a/.github/workflows/feed-parser.yml
+++ b/.github/workflows/feed-parser.yml
@@ -14,12 +14,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Create v2 directory
+        run: mkdir -p v2
       - name: Run Feed Post Parser
         uses: xaoxuu/feed-posts-parser@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          data_path: '/v2/data.json'
+          data_path: 'v2/data.json'
           posts_count: 3
           date_format: 'YYYY-MM-DD HH:mm'
       # 重新生成一下JSON
@@ -29,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           data_version: 'v2'
-          data_path: '/v2/data.json'
+          data_path: 'v2/data.json'
           sort: 'posts-desc' # 'created-desc'/'created-asc'/'updated-desc'/'updated-asc'
           exclude_issue_with_labels: '审核中, 缺少互动, 缺少文章, 风险网站' # 具有哪些标签的issue不生成到JSON中
           hide_labels: '白名单' # 这些标签不显示在前端页面

--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -31,13 +31,15 @@ jobs:
           unreachable_label: '失联'
           exclude_issue_with_labels: '审核中, 白名单, 缺少互动, 缺少文章' # 具有哪些标签的issue不进行检查
       # 检查完毕后重新生成一下JSON
+      - name: Create v2 directory
+        run: mkdir -p v2
       - name: Generate data.json
         uses: xaoxuu/issues2json@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           data_version: 'v2'
-          data_path: '/v2/data.json'
+          data_path: 'v2/data.json'
           sort: 'posts-desc' # created-desc/created-asc/updated-desc/updated-asc/version-desc/posts-desc
           exclude_issue_with_labels: '审核中, 缺少互动, 缺少文章, 风险网站' # 具有哪些标签的issue不生成到JSON中
           hide_labels: '白名单' # 这些标签不显示在前端页面


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions workflows to correctly generate the `v2/data.json` file for the dynamic 友链 (friend links) feature.

## Changes
- Fixed `data_path` from `/v2/data.json` to `v2/data.json` (removed leading slash) in both workflows
- Added `mkdir -p v2` step to ensure the directory exists before JSON generation
- Applied fixes to both:
  - `.github/workflows/links-checker.yml`
  - `.github/workflows/feed-parser.yml`

## Why This Fixes the Issue
1. The leading slash in the path (`/v2/data.json`) was causing path resolution issues in GitHub Actions
2. The `v2` directory wasn't being created, which could cause the JSON generation to fail
3. These changes ensure the workflow can successfully create and populate the JSON file in the `output` branch

## Testing
After merging, you can test by:
1. Creating a test issue with friend link information
2. Manually running the "Reachability Checker" workflow
3. Checking the `output` branch for the generated `v2/data.json` file
